### PR TITLE
feature: first version of validation testing framework

### DIFF
--- a/RuntimeValidationTests/Package.resolved
+++ b/RuntimeValidationTests/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "ba4dc220576f5dcc5f2945f7efca69aa8bf73de2246b6b1a0652fc24de27b08c",
+  "pins" : [
+    {
+      "identity" : "swift-gen",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-gen.git",
+      "state" : {
+        "revision" : "5bd20fb662e1ead7ee47df6bb0a15398295f2e06",
+        "version" : "0.4.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
+        "version" : "1.0.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/RuntimeValidationTests/Package.swift
+++ b/RuntimeValidationTests/Package.swift
@@ -6,7 +6,27 @@ import PackageDescription
 let package = Package(
     name: "ValidationTests",
     products: [],
+    dependencies: [
+        .package(url: "https://github.com/pointfreeco/swift-gen.git", from: "0.4.0"),
+        .package(url: "https://github.com/apple/swift-numerics.git", from: "1.0.2"),
+    ],
     targets: [
-        .testTarget(name: "ValidationTests"),
+        .target(
+            name: "ValidationTesting",
+            dependencies: [
+                .product(name: "Numerics", package: "swift-numerics"),
+            ]
+        ),
+        .testTarget(
+            name: "ValidationTestingTests",
+            dependencies: ["ValidationTesting"]
+        ),
+        .testTarget(
+            name: "ValidationTests",
+            dependencies: [
+                "ValidationTesting",
+                .product(name: "Gen", package: "swift-gen"),
+            ]
+        ),
     ]
 )

--- a/RuntimeValidationTests/Sources/ValidationTesting/ValidationTesting.swift
+++ b/RuntimeValidationTests/Sources/ValidationTesting/ValidationTesting.swift
@@ -1,0 +1,141 @@
+import _Differentiation
+import Numerics
+import Testing
+
+// MARK: Gradient Validation
+
+public func validateGradient<S, T>(
+    of function: @differentiable(reverse) (S) -> T,
+    with gradientTruth: (S) -> S.TangentVector,
+    at point: S
+) where S: Differentiable, T: Differentiable, T: FloatingPoint, T == T.TangentVector, S.TangentVector: FloatingPoint {
+    validateGradient(
+        of: function,
+        with: gradientTruth,
+        at: point,
+        validation: { gradient, trueGradientValue in
+            gradient.isApproximatelyEqual(to: trueGradientValue)
+        }
+    )
+}
+
+public func validateGradient<S, T>(
+    of function: @differentiable(reverse) (S) -> T,
+    with gradientTruth: (S) -> S.TangentVector,
+    at point: S,
+    validation: (S.TangentVector, S.TangentVector) -> Bool
+) where S: Differentiable, T: Differentiable, T: FloatingPoint, T == T.TangentVector {
+    let vwpb = valueWithGradient(at: point, of: function)
+    
+    let gradient = vwpb.gradient
+    let gradientTruth = gradientTruth(point)
+    
+    #expect(validation(gradient, gradientTruth))
+}
+
+// MARK: VJP Validation
+
+public func validateVJP<S, T>(
+    of function: @differentiable(reverse) (S) -> T,
+    with vjpTruth: (S) -> (value: T, pullback: (T.TangentVector) -> S.TangentVector),
+    at point: S
+) where S: Differentiable, T: Differentiable, T: FloatingPoint, T == T.TangentVector, S.TangentVector: FloatingPoint {
+    validateVJP(
+        of: function,
+        with: vjpTruth,
+        at: point,
+        withTangentVector: .init(1), // TODO: we shouldn't set this as we need to validate a variety of tangentVectors as well to fully validate the vjp
+        valueValidation: { gradient, gradientTruth in gradient == gradientTruth }
+    )
+}
+
+public func validateVJP<S, T>(
+    of function: @differentiable(reverse) (S) -> T,
+    with vjpTruth: (S) -> (value: T, pullback: (T.TangentVector) -> S.TangentVector),
+    at point: S,
+    pullbackValidation: (S.TangentVector, S.TangentVector) -> Bool
+) where S: Differentiable, T: Differentiable, T: FloatingPoint, T == T.TangentVector {
+    validateVJP(
+        of: function,
+        with: vjpTruth,
+        at: point,
+        withTangentVector: .init(1), // TODO: we shouldn't set this as we need to validate a variety of tangentVectors as well to fully validate the vjp
+        valueValidation: { value, valueTruth in value == valueTruth },
+        pullbackValidation: pullbackValidation
+    )
+}
+
+public func validateVJP<S, T>(
+    of function: @differentiable(reverse) (S) -> (T),
+    with vjpTruth: (S) -> (value: T, pullback: (T.TangentVector) -> S.TangentVector),
+    at point: S,
+    withTangentVector tangentVector: T.TangentVector
+) where S: Differentiable, T: Differentiable & Equatable, S.TangentVector: FloatingPoint {
+    validateVJP(
+        of: function,
+        with: vjpTruth,
+        at: point,
+        withTangentVector: tangentVector,
+        valueValidation: { value, valueTruth in value == valueTruth },
+        pullbackValidation: { gradient, trueGradient in
+            gradient.isApproximatelyEqual(to: trueGradient)
+        }
+    )
+}
+
+public func validateVJP<S, T>(
+    of function: @differentiable(reverse) (S) -> T,
+    with vjpTruth: (S) -> (value: T, pullback: (T.TangentVector) -> S.TangentVector),
+    at point: S,
+    withTangentVector tangentVector: T.TangentVector,
+    valueValidation: (T, T) -> Bool
+) where S: Differentiable, T: Differentiable, S.TangentVector: FloatingPoint {
+    validateVJP(
+        of: function,
+        with: vjpTruth,
+        at: point,
+        withTangentVector: tangentVector,
+        valueValidation: valueValidation,
+        pullbackValidation: { gradient, trueGradient in
+            gradient.isApproximatelyEqual(to: trueGradient)
+        }
+    )
+}
+
+public func validateVJP<S, T>(
+    of function: @differentiable(reverse) (S) -> T,
+    with vjpTruth: (S) -> (value: T, pullback: (T.TangentVector) -> S.TangentVector),
+    at point: S,
+    withTangentVector tangentVector: T.TangentVector,
+    pullbackValidation: (S.TangentVector, S.TangentVector) -> Bool
+) where S: Differentiable, T: Differentiable & Equatable {
+    validateVJP(
+        of: function,
+        with: vjpTruth,
+        at: point,
+        withTangentVector: tangentVector,
+        valueValidation: { value, valueTruth in value == valueTruth },
+        pullbackValidation: pullbackValidation
+    )
+}
+
+public func validateVJP<S, T>(
+    of function: @differentiable(reverse) (S) -> T,
+    with vjpTruth: (S) -> (value: T, pullback: (T.TangentVector) -> S.TangentVector),
+    at point: S,
+    withTangentVector tangentVector: T.TangentVector,
+    valueValidation: (T, T) -> Bool,
+    pullbackValidation: (S.TangentVector, S.TangentVector) -> Bool
+) where S: Differentiable, T: Differentiable {
+    let vwpb = valueWithPullback(at: point, of: function)
+    let vwpbTruth = vjpTruth(point)
+    
+    let value = vwpb.value
+    let valueTruth = vwpbTruth.value
+    
+    let pullback = vwpb.pullback(tangentVector)
+    let pullbackTruth = vwpb.pullback(tangentVector)
+
+    #expect(valueValidation(value, valueTruth))
+    #expect(pullbackValidation(pullback, pullbackTruth))
+}

--- a/RuntimeValidationTests/Tests/ValidationTestingTests/ValidationTestingTests.swift
+++ b/RuntimeValidationTests/Tests/ValidationTestingTests/ValidationTestingTests.swift
@@ -1,0 +1,42 @@
+import _Differentiation
+import Testing
+import ValidationTesting
+
+@differentiable(reverse)
+func squared(_ x: Double) -> Double {
+    x * x
+}
+
+func vjpSquaredTruth(_ x: Double) -> (value: Double, pullback: (Double) -> Double) {
+    (
+        value: x * x,
+        pullback: { v in
+            2 * x * v
+        }
+    )
+}
+
+func gradientSquaredTruth(_ x: Double) -> Double {
+    2 * x
+}
+
+@Suite
+struct ValidationTestingTests {
+    @Test(arguments: [1.0])
+    func testVJPValidation(x: Double) {
+        validateVJP(
+            of: { x in squared(x) }, // we can call the function directly with upcoming compiler fix
+            with: vjpSquaredTruth,
+            at: x
+        )
+    }
+    
+    @Test(arguments: [1.0])
+    func testGradientValidation(x: Double) {
+        validateGradient(
+            of: { x in squared(x) }, // we can call the function directly with upcoming compiler fix
+            with: gradientSquaredTruth,
+            at: x
+        )
+    }
+}

--- a/RuntimeValidationTests/Tests/ValidationTests/LaurentPolynomials.swift
+++ b/RuntimeValidationTests/Tests/ValidationTests/LaurentPolynomials.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+import _Differentiation
+import Gen
+import ValidationTesting
+
+@differentiable(reverse, wrt: x)
+func laurentPolynomial(variable x: Double, coefficients: Dictionary<Int, Double>, center c: Double) -> Double {
+    var result = 0.0
+    for (n, coefficient) in coefficients {
+        let n = Double(n)
+        result += coefficient * pow(x - c, n)
+    }
+    return result
+}
+
+func laurentPolynomialDerivative(variable x: Double, coefficients: Dictionary<Int, Double>, center c: Double) -> Double {
+    var result = 0.0
+    for (n, coefficient) in coefficients {
+        if n == 0 { continue }
+        let n = Double(n)
+        result += n * coefficient * pow(x - c, n - 1)
+    }
+    return result
+}
+
+@Test(arguments:
+        zip(
+            Gen.double(in: -10.0...10.0),
+            zip(Gen.int(in: -20...20), Gen.double(in: -100...100)).dictionary(ofAtMost: Gen.int(in: 0...100)),
+            Gen.always(0)
+        ).array(of: .always(10)).run()
+)
+func laurentPolynomials(x: Double, coefficients: [Int: Double], center: Double) {
+    validateGradient(
+        of: { x in laurentPolynomial(variable: x, coefficients: coefficients, center: center) },
+        with: { x in laurentPolynomialDerivative(variable: x, coefficients: coefficients, center: center) },
+        at: x
+    )
+}

--- a/RuntimeValidationTests/Tests/ValidationTests/OperatorTests.swift
+++ b/RuntimeValidationTests/Tests/ValidationTests/OperatorTests.swift
@@ -1,0 +1,31 @@
+import _Differentiation
+import Gen
+import Testing
+import ValidationTesting
+
+@Suite("Operator Tests")
+struct OperatorTests {
+    @Test func addition() throws {
+        let vwpb = valueWithPullback(at: 2.0, 1.0, of: +)
+        #expect(vwpb.value == 3.0)
+        #expect(vwpb.pullback(1.0) == (1.0, 1.0))
+    }
+    
+    @Test func substraction() throws {
+        let vwpb = valueWithPullback(at: 2.0, 1.0, of: -)
+        #expect(vwpb.value == 1.0)
+        #expect(vwpb.pullback(1.0) == (1.0, -1.0))
+    }
+    
+    @Test func multiplication() throws {
+        let vwpb = valueWithPullback(at: 2.0, 3.0, of: *)
+        #expect(vwpb.value == 6.0)
+        #expect(vwpb.pullback(1.0) == (3.0, 2.0))
+    }
+    
+    @Test func division() throws {
+        let vwpb = valueWithPullback(at: 2.0, 4.0, of: /)
+        #expect(vwpb.value == 0.5)
+        #expect(vwpb.pullback(1.0) == (0.25, -0.125))
+    }
+}

--- a/RuntimeValidationTests/Tests/ValidationTests/TGMathDerivatives.swift
+++ b/RuntimeValidationTests/Tests/ValidationTests/TGMathDerivatives.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Gen
+import Testing
+import ValidationTesting
+
+@Suite("TGMath Derivatives")
+struct TGMathDerivativesTests {
+    @Test(arguments: Gen.double(in: 0...10000).array(of: .always(100)).run())
+    func testSqrt(_ x: Double) {
+        validateVJP(
+            of: { x in sqrt(x) },
+            with: { x in (sqrt(x), { v in v / (2 * sqrt(x)) } ) },
+            at: x
+        )
+    }
+}

--- a/RuntimeValidationTests/Tests/ValidationTests/ValidationTestingInvalidResultsTests.swift
+++ b/RuntimeValidationTests/Tests/ValidationTests/ValidationTestingInvalidResultsTests.swift
@@ -1,0 +1,44 @@
+import _Differentiation
+import Gen
+import Testing
+
+@differentiable(reverse)
+func oneOverX(_ x: Double) -> Double {
+    1 / x
+}
+
+func _vjpOneOverX(_ x: Double) -> (value: Double, pullback: (Double) -> Double) {
+    (
+        value: 1 / x,
+        pullback: { v in
+            -v / (x * x)
+        }
+    )
+}
+
+func validateVJPWithError<S, T>(
+    of function: @differentiable(reverse) (S) -> T,
+    with vjpTruth: (S) -> (value: T, pullback: (T.TangentVector) -> S.TangentVector),
+    at point: S
+) where S: Differentiable, T: Differentiable, T: FloatingPoint, T == T.TangentVector, S.TangentVector: FloatingPoint, S.TangentVector == Double {
+    let vwpb = valueWithPullback(at: point, of: function)
+    let vwpbTruth = vjpTruth(point)
+    
+    let value = vwpb.value
+    let valueTruth: T = vwpbTruth.value
+    
+    let pullback = vwpb.pullback(.init(1))
+    let pullbackTruth = vwpbTruth.pullback(.init(1))
+
+    #expect(value == valueTruth)
+    withKnownIssue("Caused by S.TangentVector == Double generic requirement of this function, works fine when removed") {
+        #expect(pullback == pullbackTruth)
+    }
+}
+
+@Test(
+    arguments: Gen.double(in: -100...100).array(of: .always(100)).run()
+)
+func testOneOverX(_ x: Double) {
+    validateVJPWithError(of: { x in oneOverX(x) }, with: { x in _vjpOneOverX(x) }, at: x)
+}

--- a/RuntimeValidationTests/Tests/ValidationTests/ValidationTests.swift
+++ b/RuntimeValidationTests/Tests/ValidationTests/ValidationTests.swift
@@ -3,7 +3,7 @@ import Testing
 @Suite("Pipeline validation tests")
 struct SanityChecksTests {
     @Test("Test that always passes") func alwaysPass() throws {
-        #expect(true)
+        #expect(Bool(true))
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
     }
     


### PR DESCRIPTION
This adds the first version of a validation testing framework. We might be able to improve this further by incorporating it deeper with the Test macro. For now this seems like a good first attempt.
In the future we'd like to add a "shrinking feature" like @tmcdonell pointed out something like Haskell's hedgehog has. 
Once this is somewhat mature the testing framework could move to a separate repo if it's useful to others. For now it's too focussed on Differentiation related testing.