### PR TITLE
CI: add automated benchmarks job

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,41 @@
+name: Differentiation Benchmarks
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  benchmark:
+    name: Run Differentiation benchmarks
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        swift: ["6.0.3"]
+    container: swift:${{ matrix.swift }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: apt-get -q update && apt-get install -y libjemalloc-dev python3
+      - name: Run benchmarks
+        run: cd RuntimePerformanceTests && swift package --allow-writing-to-package-directory benchmark --format histogramPercentiles --path benchmark-raw-output
+      - name: Process benchmarks
+        run: cd RuntimePerformanceTests && ./parse-benchmarks
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: package-benchmark
+          tool: 'customBiggerIsBetter'
+          output-file-path: RuntimePerformanceTests/bench-mean-results.json
+          benchmark-data-dir-path: "RuntimePerformanceTests/results"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: true
+          summary-always: true
+          alert-comment-cc-users: '@JaapWijnen'

--- a/RuntimePerformanceTests/.gitignore
+++ b/RuntimePerformanceTests/.gitignore
@@ -6,3 +6,4 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+benchmark-raw-output

--- a/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
+++ b/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
@@ -43,7 +43,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                let thing = gradient(at: 2, of: oneOperation)
+                let thing = gradient(at: 2, of: { v in oneOperation(a: v) })
                 blackHole(thing)
             }
         }
@@ -57,7 +57,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: sixteenOperations))
+                blackHole(gradient(at: 2, of: { v in sixteenOperations(a: v) }))
             }
         }
     )
@@ -70,7 +70,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: twoComposedOperations))
+                blackHole(gradient(at: 2, of: { v in twoComposedOperations(a: v) }))
             }
         }
     )
@@ -83,7 +83,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: sixteenComposedOperations))
+                blackHole(gradient(at: 2, of: { v in sixteenComposedOperations(a: v) }))
             }
         }
     )
@@ -99,7 +99,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: oneOperationLoopedSmall))
+                blackHole(gradient(at: 2, of: { v in oneOperationLoopedSmall(a: v) }))
             }
         }
     )
@@ -112,7 +112,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: fourOperationsLoopedSmall))
+                blackHole(gradient(at: 2, of: { v in fourOperationsLoopedSmall(a: v) }))
             }
         }
     )
@@ -125,7 +125,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: sixteenOperationsLoopedSmall))
+                blackHole(gradient(at: 2, of: { v in sixteenOperationsLoopedSmall(a: v) }))
             }
         }
     )
@@ -138,7 +138,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: oneOperationLooped))
+                blackHole(gradient(at: 2, of: { v in oneOperationLooped(a: v) }))
             }
         }
     )
@@ -151,7 +151,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: twoOperationsLooped))
+                blackHole(gradient(at: 2, of: { v in twoOperationsLooped(a: v) }))
             }
         }
     )
@@ -164,7 +164,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: fourOperationsLooped))
+                blackHole(gradient(at: 2, of: { v in fourOperationsLooped(a: v) }))
             }
         }
     )
@@ -177,7 +177,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: eightOperationsLooped))
+                blackHole(gradient(at: 2, of: { v in eightOperationsLooped(a: v) }))
             }
         }
     )
@@ -190,7 +190,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: sixteenOperationsLooped))
+                blackHole(gradient(at: 2, of: { v in sixteenOperationsLooped(a: v) }))
             }
         }
     )
@@ -203,7 +203,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: twoComposedOperationsLooped))
+                blackHole(gradient(at: 2, of: { v in twoComposedOperationsLooped(a: v) }))
             }
         }
     )
@@ -216,7 +216,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: sixteenComposedOperationsLooped))
+                blackHole(gradient(at: 2, of: { v in sixteenComposedOperationsLooped(a: v) }))
             }
         }
     )
@@ -232,7 +232,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 1.0, 2.0, 3.0, of: fuzzedMath1))
+                blackHole(gradient(at: 1.0, 2.0, 3.0, of: { x, y, z in fuzzedMath1(x, y, z) }))
             }
         }
     )
@@ -245,7 +245,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 1.0, 2.0, 3.0, of: fuzzedMath2))
+                blackHole(gradient(at: 1.0, 2.0, 3.0, of: { x, y, z in fuzzedMath2(x, y, z) }))
             }
         }
     )
@@ -259,7 +259,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 1.0, 2.0, 3.0, of: fuzzedMathTernary1))
+                blackHole(gradient(at: 1.0, 2.0, 3.0, of: { x, y, z in fuzzedMathTernary1(x, y, z) }))
             }
         }
     )
@@ -272,7 +272,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 1.0, 2.0, 3.0, of: fuzzedMathTernary2))
+                blackHole(gradient(at: 1.0, 2.0, 3.0, of: { x, y, z in fuzzedMathTernary2(x, y, z) }))
             }
         }
     )

--- a/RuntimePerformanceTests/parse-benchmarks
+++ b/RuntimePerformanceTests/parse-benchmarks
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import csv
+import os
+import json
+
+gh_action_formatted = []
+for file in os.listdir("./benchmark-raw-output"):
+    with open(f"./benchmark-raw-output/{file}") as bench_result:
+        # filename format: Current_run.LanguageCoverage.sixteen_composed_operations_looped.ratio.histogram.percentiles.tsv
+        name_components = file.split(".") 
+        name = f"{name_components[1]} - {name_components[2]} - {name_components[3]}"
+        for line in csv.reader(bench_result, delimiter="\t"):
+            if line[0] == "Percentile":
+                unit = line[1].strip()
+
+            # just take the 50th percentile for now
+            if line[0] == "50":
+                gh_action_formatted.append({"name": name, "unit": unit, "value": line[1]})
+
+res = json.dumps(gh_action_formatted)
+with open("bench-mean-results.json", "w") as f:
+    f.write(res)

--- a/RuntimePerformanceTests/parse-benchmarks
+++ b/RuntimePerformanceTests/parse-benchmarks
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+
+# This script is a quick-and-dirty parser for the `histogramPercentiles` outupt of package-benchmark: https://swiftpackageindex.com/ordo-one/package-benchmark/1.27.4/documentation/benchmark/exportingbenchmarks#Saved-Formats
+# that converts it into the `customBiggerIsBetter` json format needed by `github-action-benchmark`: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#examples
+# 
+# package-benchmark does support `jmh` output, but **only** for benchmarks with a throughput metric, which ours are not using (as it's not a
+# valuable metric in this case). Instead, this script just takes the 50th percentile result for each benchmark and passes that to the
+# benchmark action.
+
 import csv
 import os
 import json


### PR DESCRIPTION
This leverages the excellent https://github.com/benchmark-action/github-action-benchmark to publish our benchmarks to the github pages in this repository for all benchmarks. A couple important points here:
* Unfortunately, we can't use `jmh` output for this, as package-benchmark requirese that your benchmarks use `throughput` which isn't super valuable here
* instead, I'm using a `customBiggerIsBetter` benchmark that is produced by a very quick-and-dirty python script from the `histogramPercentiles` output
* Right now it just takes the 50th percentile, but it would be trivial to add other percentiles if we want as well
* Currently this works for one version of swift (since we only have the one in the matrix), but it is easily expandable to multiple. I'd prefer to do that as a follow-on as I want to make sure this works effectively first.
* This is a smidge hard to test without being on `main` as the GH token doesn't have push rights to the pages branch unless it's from a workflow run on `main`, but as I put in a comment below you can see that everything up until that checkout did work just fine.

I'm not married to this approach long term and there are a couple other considerations here too to be aware of:
1. This is all running on the public GH runners, meaning that there will almost certainly be a bit of variance in benchmarks just due to their load. The plan is to get a dedicated runner eventually.
2. Similar to the above, once we have a dedicated runner it may be advantageous to swap over to an influx/grafana stack with the grafana dashboards publicly viewable, but that's a future discussion

This should be a good jumping-off point for performance numbers, with the follow-on items for:
* benching nightly toolchains
* handling other percentiles, if desired