### PR TITLE
Fix automated benchmarks git ownership

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
         run: cd RuntimePerformanceTests && swift package --allow-writing-to-package-directory benchmark --format histogramPercentiles --path benchmark-raw-output
       - name: Process benchmarks
         run: cd RuntimePerformanceTests && ./parse-benchmarks
-
+      - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:


### PR DESCRIPTION
This fixes the `dubious ownership` error for auto benchmark publishing. See the successful job here: https://github.com/differentiable-swift/swift-differentiation-testing/actions/runs/12648429001/job/35242748726

and the commit it generated on the `gh-pages` branch here: https://github.com/differentiable-swift/swift-differentiation-testing/commit/a0097329c32fb16f038059f147d543a51c2a8ad9

Solution from https://github.com/actions/checkout/issues/766