### PR TITLE
Fix/improve microbenchmarks

### DIFF
--- a/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
+++ b/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
@@ -38,6 +38,7 @@ let benchmarks: @Sendable () -> Void = {
         "one operation",
         forward: { benchmark in
             var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
                 x = oneOperation(a: x)
             }
@@ -64,6 +65,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             var y: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
                 y = gradient(at: y, of: { v in sixteenOperations(a: v) })
             }
@@ -74,6 +76,7 @@ let benchmarks: @Sendable () -> Void = {
         "two composed operations",
         forward: { benchmark in
             var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
                 x = twoComposedOperations(a: x)
             }
@@ -81,6 +84,7 @@ let benchmarks: @Sendable () -> Void = {
         },
         reverse: { benchmark in
             var y: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
                 y = gradient(at: y, of: { v in twoComposedOperations(a: v) })
             }

--- a/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
+++ b/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
@@ -309,54 +309,98 @@ let benchmarks: @Sendable () -> Void = {
     Benchmark(
         "fuzzed arithmetic 1",
         forward: { benchmark in
+            var (x, y, z): (Float, Float, Float) = (1.0, 2.0, 3.0)
+            clobber(&x); clobber(&y); clobber(&z)
+            benchmark.startMeasurement()
             for _ in benchmark.scaledIterations {
-                blackHole(fuzzedMath1(1.0, 2.0, 3.0))
+                x = fuzzedMath1(x, y, z)
+                y += x
+                z += x
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var (x, y, z): (Float, Float, Float) = (1.0, 2.0, 3.0)
+            clobber(&x); clobber(&y); clobber(&z)
+            benchmark.startMeasurement()
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 1.0, 2.0, 3.0, of: { x, y, z in fuzzedMath1(x, y, z) }))
+                (x, y, z) = gradient(at: 1.0, 2.0, 3.0, of: { x, y, z in fuzzedMath1(x, y, z) })
             }
+            benchmark.stopMeasurement()
+            blackHole(x); blackHole(y); blackHole(z)
         }
     )
     Benchmark(
         "fuzzed arithmetic 2",
         forward: { benchmark in
+            var (x, y, z): (Float, Float, Float) = (1.0, 2.0, 3.0)
+            clobber(&x); clobber(&y); clobber(&z)
+            benchmark.startMeasurement()
             for _ in benchmark.scaledIterations {
-                blackHole(fuzzedMath2(1.0, 2.0, 3.0))
+                x = fuzzedMath2(x, y, z)
+                y += x
+                z += x
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var (x, y, z): (Float, Float, Float) = (1.0, 2.0, 3.0)
+            clobber(&x); clobber(&y); clobber(&z)
+            benchmark.startMeasurement()
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 1.0, 2.0, 3.0, of: { x, y, z in fuzzedMath2(x, y, z) }))
+                (x, y, z) = gradient(at: 1.0, 2.0, 3.0, of: { x, y, z in fuzzedMath2(x, y, z) })
             }
+            benchmark.stopMeasurement()
+            blackHole(x); blackHole(y); blackHole(z)
         }
     )
 
     Benchmark(
         "fuzzed arithmetic with ternary operators 1",
         forward: { benchmark in
+            var (x, y, z): (Float, Float, Float) = (1.0, 2.0, 3.0)
+            clobber(&x); clobber(&y); clobber(&z)
+            benchmark.startMeasurement()
             for _ in benchmark.scaledIterations {
-                blackHole(fuzzedMathTernary1(1.0, 2.0, 3.0))
+                x = fuzzedMathTernary1(x, y, z)
+                y += x
+                z += x
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var (x, y, z): (Float, Float, Float) = (1.0, 2.0, 3.0)
+            clobber(&x); clobber(&y); clobber(&z)
+            benchmark.startMeasurement()
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 1.0, 2.0, 3.0, of: { x, y, z in fuzzedMathTernary1(x, y, z) }))
+                (x, y, z) = gradient(at: 1.0, 2.0, 3.0, of: { x, y, z in fuzzedMathTernary1(x, y, z) })
             }
+            benchmark.stopMeasurement()
+            blackHole(x); blackHole(y); blackHole(z)
         }
     )
     Benchmark(
         "fuzzed arithmetic with ternary operators 2",
         forward: { benchmark in
+            var (x, y, z): (Float, Float, Float) = (1.0, 2.0, 3.0)
+            clobber(&x); clobber(&y); clobber(&z)
+            benchmark.startMeasurement()
             for _ in benchmark.scaledIterations {
-                blackHole(fuzzedMathTernary2(1.0, 2.0, 3.0))
+                x = fuzzedMathTernary2(x, y, z)
+                y += x
+                z += x
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var (x, y, z): (Float, Float, Float) = (1.0, 2.0, 3.0)
+            clobber(&x); clobber(&y); clobber(&z)
+            benchmark.startMeasurement()
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 1.0, 2.0, 3.0, of: { x, y, z in fuzzedMathTernary2(x, y, z) }))
+                (x, y, z) = gradient(at: 1.0, 2.0, 3.0, of: { x, y, z in fuzzedMathTernary2(x, y, z) })
             }
+            benchmark.stopMeasurement()
+            blackHole(x); blackHole(y); blackHole(z)
         }
     )
 }

--- a/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
+++ b/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
@@ -37,41 +37,53 @@ let benchmarks: @Sendable () -> Void = {
     Benchmark(
         "one operation",
         forward: { benchmark in
+            var x: Float = 2.0
             for _ in benchmark.scaledIterations {
-                blackHole(oneOperation(a: 2))
+                x = oneOperation(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var y: Float = 2.0
             for _ in benchmark.scaledIterations {
-                let thing = gradient(at: 2, of: { v in oneOperation(a: v) })
-                blackHole(thing)
+                y = gradient(at: y, of: { v in oneOperation(a: v) })
             }
+            blackHole(y)
         }
     )
     Benchmark(
         "sixteen operations",
         forward: { benchmark in
+            var x = Float.random(in: 1.5...2.5)
+            benchmark.startMeasurement()
             for _ in benchmark.scaledIterations {
-                blackHole(sixteenOperations(a: 2))
+                x = sixteenOperations(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var y: Float = 2.0
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: { v in sixteenOperations(a: v) }))
+                y = gradient(at: y, of: { v in sixteenOperations(a: v) })
             }
+            blackHole(y)
         }
     )
     Benchmark(
         "two composed operations",
         forward: { benchmark in
+            var x: Float = 2.0
             for _ in benchmark.scaledIterations {
-                blackHole(twoComposedOperations(a: 2))
+                x = twoComposedOperations(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var y: Float = 2.0
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: { v in twoComposedOperations(a: v) }))
+                y = gradient(at: y, of: { v in twoComposedOperations(a: v) })
             }
+            blackHole(y)
         }
     )
     Benchmark(

--- a/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
+++ b/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
@@ -54,7 +54,8 @@ let benchmarks: @Sendable () -> Void = {
     Benchmark(
         "sixteen operations",
         forward: { benchmark in
-            var x = Float.random(in: 1.5...2.5)
+            var x: Float = 2.0
+            clobber(&x)
             benchmark.startMeasurement()
             for _ in benchmark.scaledIterations {
                 x = sixteenOperations(a: x)

--- a/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
+++ b/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
@@ -45,11 +45,11 @@ let benchmarks: @Sendable () -> Void = {
             blackHole(x)
         },
         reverse: { benchmark in
-            var y: Float = 2.0
+            var x: Float = 2.0
             for _ in benchmark.scaledIterations {
-                y = gradient(at: y, of: { v in oneOperation(a: v) })
+                x = gradient(at: x, of: { v in oneOperation(a: v) })
             }
-            blackHole(y)
+            blackHole(x)
         }
     )
     Benchmark(
@@ -64,12 +64,12 @@ let benchmarks: @Sendable () -> Void = {
             blackHole(x)
         },
         reverse: { benchmark in
-            var y: Float = 2.0
+            var x: Float = 2.0
             clobber(&x)
             for _ in benchmark.scaledIterations {
-                y = gradient(at: y, of: { v in sixteenOperations(a: v) })
+                x = gradient(at: x, of: { v in sixteenOperations(a: v) })
             }
-            blackHole(y)
+            blackHole(x)
         }
     )
     Benchmark(
@@ -83,25 +83,31 @@ let benchmarks: @Sendable () -> Void = {
             blackHole(x)
         },
         reverse: { benchmark in
-            var y: Float = 2.0
+            var x: Float = 2.0
             clobber(&x)
             for _ in benchmark.scaledIterations {
-                y = gradient(at: y, of: { v in twoComposedOperations(a: v) })
+                x = gradient(at: x, of: { v in twoComposedOperations(a: v) })
             }
-            blackHole(y)
+            blackHole(x)
         }
     )
     Benchmark(
         "sixteen composed operations",
         forward: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(sixteenComposedOperations(a: 2))
+                x = sixteenComposedOperations(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: { v in sixteenComposedOperations(a: v) }))
+                x = gradient(at: x, of: { v in sixteenComposedOperations(a: v) })
             }
+            blackHole(x)
         }
     )
     
@@ -110,131 +116,191 @@ let benchmarks: @Sendable () -> Void = {
     Benchmark(
         "one operation looped (small)",
         forward: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(oneOperationLoopedSmall(a: 2))
+                x = oneOperationLoopedSmall(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: { v in oneOperationLoopedSmall(a: v) }))
+                x = gradient(at: x, of: { v in oneOperationLoopedSmall(a: v) })
             }
+            blackHole(x)
         }
     )
     Benchmark(
         "four operations looped (small)",
         forward: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(fourOperationsLoopedSmall(a: 2))
+                x = fourOperationsLoopedSmall(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: { v in fourOperationsLoopedSmall(a: v) }))
+                x = gradient(at: x, of: { v in fourOperationsLoopedSmall(a: v) })
             }
+            blackHole(x)
         }
     )
     Benchmark(
         "sixteen operations looped (small)",
         forward: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(sixteenOperationsLoopedSmall(a: 2))
+                x = sixteenOperationsLoopedSmall(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: { v in sixteenOperationsLoopedSmall(a: v) }))
+                x = gradient(at: x, of: { v in sixteenOperationsLoopedSmall(a: v) })
             }
+            blackHole(x)
         }
     )
     Benchmark(
         "one operation looped",
         forward: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(oneOperationLooped(a: 2))
+                x = oneOperationLooped(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: { v in oneOperationLooped(a: v) }))
+                x = gradient(at: x, of: { v in oneOperationLooped(a: v) })
             }
+            blackHole(x)
         }
     )
     Benchmark(
         "two operations looped",
         forward: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(twoOperationsLooped(a: 2))
+                x = twoOperationsLooped(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: { v in twoOperationsLooped(a: v) }))
+                x = gradient(at: x, of: { v in twoOperationsLooped(a: v) })
             }
+            blackHole(x)
         }
     )
     Benchmark(
         "four operations looped",
         forward: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(fourOperationsLooped(a: 2))
+                x = fourOperationsLooped(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: { v in fourOperationsLooped(a: v) }))
+                x = gradient(at: x, of: { v in fourOperationsLooped(a: v) })
             }
+            blackHole(x)
         }
     )
     Benchmark(
         "eight operations looped",
         forward: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(eightOperationsLooped(a: 2))
+                x = eightOperationsLooped(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: { v in eightOperationsLooped(a: v) }))
+                x = gradient(at: x, of: { v in eightOperationsLooped(a: v) })
             }
+            blackHole(x)
         }
     )
     Benchmark(
         "sixteen operations looped",
         forward: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(sixteenOperationsLooped(a: 2))
+                x = sixteenOperationsLooped(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: { v in sixteenOperationsLooped(a: v) }))
+                x = gradient(at: x, of: { v in sixteenOperationsLooped(a: v) })
             }
+            blackHole(x)
         }
     )
     Benchmark(
         "two composed operations looped",
         forward: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(twoComposedOperationsLooped(a: 2))
+                x = twoComposedOperationsLooped(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: { v in twoComposedOperationsLooped(a: v) }))
+                x = gradient(at: x, of: { v in twoComposedOperationsLooped(a: v) })
             }
+            blackHole(x)
         }
     )
     Benchmark(
         "sixteen composed operations looped",
         forward: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(sixteenComposedOperationsLooped(a: 2))
+                x = sixteenComposedOperationsLooped(a: x)
             }
+            blackHole(x)
         },
         reverse: { benchmark in
+            var x: Float = 2.0
+            clobber(&x)
             for _ in benchmark.scaledIterations {
-                blackHole(gradient(at: 2, of: { v in sixteenComposedOperationsLooped(a: v) }))
+                x = gradient(at: x, of: { v in sixteenComposedOperationsLooped(a: v) })
             }
+            blackHole(x)
         }
     )
 

--- a/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
+++ b/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Benchmark.swift
@@ -5,7 +5,7 @@ import _Differentiation
 enum CustomMeasurement {
     static let forward = BenchmarkMetric.custom("run forward (ns)", polarity: .prefersSmaller, useScalingFactor: true)
     static let reverse = BenchmarkMetric.custom("run reverse (ns)", polarity: .prefersSmaller, useScalingFactor: true)
-    static let ratio = BenchmarkMetric.custom("ratio", polarity: .prefersSmaller, useScalingFactor: true)
+    static let ratio = BenchmarkMetric.custom("ratio", polarity: .prefersSmaller, useScalingFactor: false)
 }
 
 extension BenchmarkMetric: @unchecked @retroactive Sendable {}

--- a/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Blackhole/Blackhole.swift
+++ b/RuntimePerformanceTests/Benchmarks/LanguageCoverage/Blackhole/Blackhole.swift
@@ -1,0 +1,10 @@
+/// `inout` variant of package-benchmark's `blackHole`.
+/// This forces the compiler to assume that `x` is mutated.
+/// Can be used to prevent loop-invariant code motion and const-folding.
+@_optimize(none)
+public func blackHoleInout(_ x: inout some Any) {}
+
+/// Same functionality as `blackHoleInout`, but takes raw pointer instead.
+/// Anecdotal evidence suggests that this one produces fewer spurious instructions.
+@_optimize(none)
+public func clobber(_ x: UnsafeMutableRawPointer) {}


### PR DESCRIPTION
This PR fixes some issues with the microbenchmarks in `LanguageCoverage`.

# No Scaling Factor For Ratio
Both forward and reverse passes are scaled by the same amount. The ratio should not be scaled.
```
    ╒══════════════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
    │                 ratio *                  │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
    ╞══════════════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
    │                  alpha                   │       0 │       0 │       0 │       0 │       0 │       0 │       0 │      68 │
    ├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
    │               Current_run                │      73 │      79 │      82 │      82 │      82 │      85 │      85 │      68 │
    ├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
    │                    Δ                     │      73 │      79 │      82 │      82 │      82 │      85 │      85 │       0 │
    ├──────────────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
    │              Improvement %               │       0 │       0 │       0 │       0 │       0 │       0 │       0 │       0 │
    ╘══════════════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```
# New Black Hole Functions
```swift
@_optimize(none)
public func clobber(_ x: UnsafeMutableRawPointer) {}
```
This forces the compiler to assume that whatever is passed to this function can be mutated as well.

# Benchmarks Optimized Away
`Benchmark.blackHole` only forces the compiler to assume that `x` is read with possible side-effects. E.g. it could possibly be printed to `stdout`. It DOES NOT force the compiler to assume that `x` can be mutated.
```swift
{      benchmark in
        for _ in benchmark.scaledIterations {
                blackHole(sixteenOperations(a: 2))
         }
}
```

This is equivalent to
```swift
{ benchmark in
    for _ in benchmark.scaledIterations {
        let _x1 = sixteenOperations(a: 2)
        blackHole(_x1)
    }
}
```
The `blackHole` thwarts dead-code elimination, but not loop-invariant code motion and constant-folding. So, the above is equivalent to
```swift
{ benchmark in
    let _x1 = sixteenOperations(a: 2)
    for _ in benchmark.scaledIterations {
        blackHole(_x1)
    }
}
```

Instead, this should be something like
```swift
{ benchmark in
    var x: Float = 2.0
    clobber(&x)  // mandatory in some cases, more on this later
    for _ in benchmark.scaledIterations {
        x = sixteenOperations(a: x)
    }
    blackHole(x)
}
```
`clobber` forces the compiler to assume that `x` is both read from and written to. The fixed-point iteration introduces a loop-carried dependency, and the `blackHole` at the end prevents dead-code elimination. The compiler cannot do any funky business with this.

The fixed point iteration is especially important to better estimate the true latency of the function.

# Why is `clobber` needed here?
I discovered that the benchmark loop can _sometimes_ be optimized away without the clobber. E.g. this was happening in "sixteen operations" and a few others, but not all of them.
```swift
{ benchmark in
    // whole benchmark loop gets optimized away
    var x: Float = 2.0  // no clobber
    for _ in benchmark.scaledIterations {
        x = sixteenOperations(a: x)
    }
    blackHole(x)
}
```
