### PR TITLE
CI/benchmark influx

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,9 +18,20 @@ jobs:
     container: swift:${{ matrix.swift }}
     steps:
       - uses: actions/checkout@v4
-      - run: apt-get -q update && apt-get install -y libjemalloc-dev python3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify Python version
+        run: python --version
+      - name: Install dependencies
+        run: |
+          python -m pip install "pandas==2.2.3"
+      - name: Verify package installation
+        run: python -c "import pandas as pd; print(pd.__version__)"
+      - run: apt-get -q update && apt-get install -y libjemalloc-dev
       - name: Run benchmarks
-        run: cd RuntimePerformanceTests && swift package --allow-writing-to-package-directory benchmark --format histogramPercentiles --path benchmark-raw-output
+        run: cd RuntimePerformanceTests && swift package --allow-writing-to-package-directory benchmark --format influx --path benchmark-raw-output
       - name: Process benchmarks
         run: cd RuntimePerformanceTests && ./parse-benchmarks
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/RuntimePerformanceTests/Package.resolved
+++ b/RuntimePerformanceTests/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "da430e475333b1c44735f2fa2039f17a0950678e30067467551e17414a6dee97",
+  "originHash" : "c904a6a501a9d1f10fa2dd02f91cfba2ca658033d434e746e671ebf936476691",
   "pins" : [
     {
       "identity" : "hdrhistogram-swift",
@@ -15,7 +15,6 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/loonatick-src/package-benchmark",
       "state" : {
-        "branch" : "main",
         "revision" : "94f97d3c8e766869c641129f73bed83feb422ae5"
       }
     },

--- a/RuntimePerformanceTests/Package.resolved
+++ b/RuntimePerformanceTests/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c904a6a501a9d1f10fa2dd02f91cfba2ca658033d434e746e671ebf936476691",
+  "originHash" : "28214c62b29d4d3a3677354fa7469bca9ef6274b483b192d5d70e52e91edd886",
   "pins" : [
     {
       "identity" : "hdrhistogram-swift",
@@ -13,9 +13,9 @@
     {
       "identity" : "package-benchmark",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/loonatick-src/package-benchmark",
+      "location" : "https://github.com/ordo-one/package-benchmark",
       "state" : {
-        "revision" : "94f97d3c8e766869c641129f73bed83feb422ae5"
+        "revision" : "3db567fb696772df6ba38e47428b3aae94d6f95b"
       }
     },
     {

--- a/RuntimePerformanceTests/Package.resolved
+++ b/RuntimePerformanceTests/Package.resolved
@@ -1,22 +1,22 @@
 {
-  "originHash" : "429b40215857f8815df868444cc297cc285e2ed32bfe603593f661571d61634d",
+  "originHash" : "da430e475333b1c44735f2fa2039f17a0950678e30067467551e17414a6dee97",
   "pins" : [
     {
       "identity" : "hdrhistogram-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/HdrHistogram/hdrhistogram-swift",
       "state" : {
-        "revision" : "a69fa24d7b70421870cafa86340ece900489e17e",
-        "version" : "0.1.2"
+        "revision" : "93a1618c8aa20f6a521a9da656a3e0591889e9dc",
+        "version" : "0.1.3"
       }
     },
     {
       "identity" : "package-benchmark",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-benchmark",
+      "location" : "https://github.com/loonatick-src/package-benchmark",
       "state" : {
-        "revision" : "51fffb6bc58bcbaca9c1954e6e52b56f3c9c2d54",
-        "version" : "1.27.4"
+        "branch" : "main",
+        "revision" : "94f97d3c8e766869c641129f73bed83feb422ae5"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics",
       "state" : {
-        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
-        "version" : "1.0.2"
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
-        "version" : "1.4.0"
+        "revision" : "a34201439c74b53f0fd71ef11741af7e7caf01e1",
+        "version" : "1.4.2"
       }
     },
     {

--- a/RuntimePerformanceTests/Package.swift
+++ b/RuntimePerformanceTests/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .macOS(.v13),
     ],
     dependencies: [
-        .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "1.27.4")),
+        .package(url: "https://github.com/loonatick-src/package-benchmark", revision: "94f97d3c8e766869c641129f73bed83feb422ae5"),
         .package(url: "https://github.com/tayloraswift/swift-png", from: "4.4.0"),
     ],
     targets: [

--- a/RuntimePerformanceTests/Package.swift
+++ b/RuntimePerformanceTests/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
         .macOS(.v13),
     ],
     dependencies: [
-        .package(url: "https://github.com/loonatick-src/package-benchmark", revision: "94f97d3c8e766869c641129f73bed83feb422ae5"),
+         // TODO: change package-benchmark to release version tag when a release with this commit is cut
+        .package(url: "https://github.com/ordo-one/package-benchmark", revision: "3db567fb696772df6ba38e47428b3aae94d6f95b"), 
         .package(url: "https://github.com/tayloraswift/swift-png", from: "4.4.0"),
     ],
     targets: [

--- a/RuntimePerformanceTests/parse-benchmarks
+++ b/RuntimePerformanceTests/parse-benchmarks
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
-# TODO: (Chaitanya) ammend this when done
-# This script is a quick-and-dirty parser for the `histogramPercentiles` outupt of package-benchmark: https://swiftpackageindex.com/ordo-one/package-benchmark/1.27.4/documentation/benchmark/exportingbenchmarks#Saved-Formats
-# that converts it into the `customBiggerIsBetter` json format needed by `github-action-benchmark`: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#examples
-# 
+# This script is a quick-and-dirty parser for the `influx` outupt of package-benchmark: https://swiftpackageindex.com/ordo-one/package-benchmark/1.27.4/documentation/benchmark/exportingbenchmarks#Saved-Formats
+# that converts it into the `customBiggerIsBetter` json format needed by `github-action-benchmark`: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#examples.
+# This format was chosen over the others for the following reasons.
+# 1. Presents raw values instead of scaling them for pretty-prenting, normalization etc.
+# 2. Contains platform information and timestamps, all benchmark results are incomplete without this information.
 # package-benchmark does support `jmh` output, but **only** for benchmarks with a throughput metric, which ours are not using (as it's not a
 # valuable metric in this case). Instead, this script just takes the 50th percentile result for each benchmark and passes that to the
 # benchmark action.
@@ -26,9 +27,6 @@ for (test, result) in gdf:
     name_prefix = f"{test[0]} - {test[1]} - {result['metric'].iloc[0]}"
     for (_, row) in result.iterrows():
         metric = row['metric']
-        # unit = row['unit']
-        # unit, scale = renormalize(unit) 
-        # value = row['value'] / scale
         value = row['value']
         name = f"{name_prefix} - {metric}"
         unit = row['unit']

--- a/RuntimePerformanceTests/parse-benchmarks
+++ b/RuntimePerformanceTests/parse-benchmarks
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+# TODO: (Chaitanya) ammend this when done
 # This script is a quick-and-dirty parser for the `histogramPercentiles` outupt of package-benchmark: https://swiftpackageindex.com/ordo-one/package-benchmark/1.27.4/documentation/benchmark/exportingbenchmarks#Saved-Formats
 # that converts it into the `customBiggerIsBetter` json format needed by `github-action-benchmark`: https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#examples
 # 
@@ -10,20 +11,32 @@
 import csv
 import os
 import json
+import pandas as pd
+from typing import Tuple  
 
 gh_action_formatted = []
-for file in os.listdir("./benchmark-raw-output"):
-    with open(f"./benchmark-raw-output/{file}") as bench_result:
-        # filename format: Current_run.LanguageCoverage.sixteen_composed_operations_looped.ratio.histogram.percentiles.tsv
-        name_components = file.split(".") 
-        name = f"{name_components[1]} - {name_components[2]} - {name_components[3]}"
-        for line in csv.reader(bench_result, delimiter="\t"):
-            if line[0] == "Percentile":
-                unit = line[1].strip()
+df_full = pd.read_csv("./benchmark-raw-output/Current_run.influx.csv", skiprows=1)
+# select columns of interest
+df = df_full[['measurement', 'test', 'metric', 'unit', 'percentile', 'value', 'iterations']]
+# we care only about p50 at the moment
+df_medians = df[df['percentile'] == 50.0]
 
-            # just take the 50th percentile for now
-            if line[0] == "50":
-                gh_action_formatted.append({"name": name, "unit": unit, "value": line[1]})
+gdf = df_medians.groupby(['measurement', 'test'])
+for (test, result) in gdf:
+    name_prefix = f"{test[0]} - {test[1]} - {result['metric'].iloc[0]}"
+    for (_, row) in result.iterrows():
+        metric = row['metric']
+        # unit = row['unit']
+        # unit, scale = renormalize(unit) 
+        # value = row['value'] / scale
+        value = row['value']
+        name = f"{name_prefix} - {metric}"
+        unit = row['unit']
+        if metric == "runforward(ns)" or metric == "runreverse(ns)":
+            unit = 'ns'  # hard-coded case because of custom metrics
+        elif unit in ('K','M','G'):
+            unit = ''  # value in influx format not affected by dimensionless units 
+        gh_action_formatted.append({'name': name, 'unit': unit, 'value': value})
 
 res = json.dumps(gh_action_formatted)
 with open("bench-mean-results.json", "w") as f:


### PR DESCRIPTION
This PR changes the benchmark command to export results in the influx format instead of the histogram percentiles format. This has a few advantages.
1. This fixes #24, the values reported in the influx table are raw unscaled values. There can be some confusion due to the units column reporting 'K', or 'M', suggesting that the values might be scaled, but that only happens other formats like histogram percentiles.
2. The influx format exports a lot more information, including information about the machine. This information will be mandatory in case we add more than one kind of self-hosted runner in the future.
3. The format can be readily exported to a database for subsequent dashboarding if required.


## Regarding the Scaling Factors
I went spelunking into the package-benchmark codebase to try and understand how and why values are being scaled. We had been using the `histogramPercentiles` format. We can see [here](https://github.com/ordo-one/package-benchmark/blob/b98a1c10ea1cf9961287e78a9fa300e61fe0347c/Plugins/BenchmarkTool/BenchmarkTool%2BExport.swift#L217) that the output values get "normalized" before being printed.
The normalization, defined [here](https://github.com/ordo-one/package-benchmark/blob/b98a1c10ea1cf9961287e78a9fa300e61fe0347c/Sources/Benchmark/BenchmarkResult.swift#L353), is done on the basis of `timeUnits` of the benchmark. This was a little confusing because custom metrics are treated as unitless, countable metrics like malloc count. But they are being calculated from time units, which is implicitly assigned to our benchmark result. In our case there seems to be some method to the madness as our custom metric is coincidentally nanoseconds wall time too. 

[Just before that the header is also pretty-printed](https://github.com/ordo-one/package-benchmark/blob/b98a1c10ea1cf9961287e78a9fa300e61fe0347c/Plugins/BenchmarkTool/BenchmarkTool%2BExport.swift#L214) and assigned one of the 'K', 'M' etc units in parentheses. That is done using [`unitDescriptionPretty`](https://github.com/ordo-one/package-benchmark/blob/b98a1c10ea1cf9961287e78a9fa300e61fe0347c/Sources/Benchmark/BenchmarkResult.swift#L376), which also [normalizes with respect to nanoseconds](https://github.com/ordo-one/package-benchmark/blob/b98a1c10ea1cf9961287e78a9fa300e61fe0347c/Sources/Benchmark/BenchmarkResult.swift#L584).

In summary, what _I think_ is going on in package-benchmark:
1. The benchmark runner measures the walltime and automatically assigns units even though we didn't explicitly asked for that metric
2. Our custom metrics measure wall time in nanoseconds, but package-benchmark doesn't encode unit information for custom metrics and treats them as countable and dimensionless.
3. But when assigning a statistical unit ('K', 'M', 'G' etc) to our custom metric, it uses the time units assigned implicitly in item 1. E.g. if it's µs, then the unit is 'K', 'M' for ms etc. 
5. As far as I could tell, all of this has nothing to do with the scaling factor used by `benchmark.scaledIterations`, that kicks in separately for certain output formats.

