### PR TITLE
fix: handle NaNs in the `parse-benchmarks` script

### DIFF
--- a/RuntimePerformanceTests/parse-benchmarks
+++ b/RuntimePerformanceTests/parse-benchmarks
@@ -13,10 +13,12 @@ import csv
 import os
 import json
 import pandas as pd
-from typing import Tuple  
+from typing import Tuple
+from numbers import Number
+from math import isnan
 
 gh_action_formatted = []
-df_full = pd.read_csv("./benchmark-raw-output/Current_run.influx.csv", skiprows=1)
+df_full = pd.read_csv("./benchmark-raw-output/Current_run.influx.csv", skiprows=1, dtype={'unit': str})
 # select columns of interest
 df = df_full[['measurement', 'test', 'metric', 'unit', 'percentile', 'value', 'iterations']]
 # we care only about p50 at the moment
@@ -33,7 +35,9 @@ for (test, result) in gdf:
         if metric == "runforward(ns)" or metric == "runreverse(ns)":
             unit = 'ns'  # hard-coded case because of custom metrics
         elif unit in ('K','M','G'):
-            unit = ''  # value in influx format not affected by dimensionless units 
+            unit = ''  # value in influx format not affected by dimensionless units
+        elif isinstance(unit, Number) and isnan(unit):
+            unit = ''  # dataframe does not assign dtype consistently
         gh_action_formatted.append({'name': name, 'unit': unit, 'value': value})
 
 res = json.dumps(gh_action_formatted)

--- a/RuntimePerformanceTests/parse-benchmarks
+++ b/RuntimePerformanceTests/parse-benchmarks
@@ -26,7 +26,7 @@ df_medians = df[df['percentile'] == 50.0]
 
 gdf = df_medians.groupby(['measurement', 'test'])
 for (test, result) in gdf:
-    name_prefix = f"{test[0]} - {test[1]} - {result['metric'].iloc[0]}"
+    name_prefix = f"{test[0]} - {test[1]}"
     for (_, row) in result.iterrows():
         metric = row['metric']
         value = row['value']

--- a/RuntimePerformanceTests/parse-benchmarks
+++ b/RuntimePerformanceTests/parse-benchmarks
@@ -34,9 +34,7 @@ for (test, result) in gdf:
         value = row['value']
         name = f"{name_prefix} - {metric}"  # E.g. "LanguaguageCoverage - one operation - Time(wallclock)"
         unit = row['unit']
-        if metric == "runforward(ns)" or metric == "runreverse(ns)":
-            unit = 'ns'  # hard-coded case because of custom metrics
-        elif unit in ('K','M','G'):
+        if unit in ('K','M','G'):
             unit = ''  # value in influx format not affected by dimensionless units
         elif isinstance(unit, Number) and isnan(unit):
             unit = ''  # dataframe does not assign dtype consistently

--- a/RuntimePerformanceTests/parse-benchmarks
+++ b/RuntimePerformanceTests/parse-benchmarks
@@ -26,11 +26,13 @@ df_medians = df[df['percentile'] == 50.0]
 
 gdf = df_medians.groupby(['measurement', 'test'])
 for (test, result) in gdf:
-    name_prefix = f"{test[0]} - {test[1]}"
+    measurement = test[0]    # name of executable target. E.g. "LanguageCoverage", "ShallowWaterPDE"
+    benchmark_name = test[1] # name of benchmark. E.g. "one operation"
+    name_prefix = f"{measurement} - {benchmark_name}" # E.g. "LanguageCoverage - one operation (pass: forward)"
     for (_, row) in result.iterrows():
-        metric = row['metric']
+        metric = row['metric']  # E.g. Time(wallclock), Malloc(total) etc
         value = row['value']
-        name = f"{name_prefix} - {metric}"
+        name = f"{name_prefix} - {metric}"  # E.g. "LanguaguageCoverage - one operation - Time(wallclock)"
         unit = row['unit']
         if metric == "runforward(ns)" or metric == "runreverse(ns)":
             unit = 'ns'  # hard-coded case because of custom metrics


### PR DESCRIPTION
Fixes this problem: https://github.com/differentiable-swift/swift-differentiation-testing/actions/runs/14357089808/job/40248967866

For some reason some units are parsed as NaN by the Pandas dataframe constructor even if `dtype` for `"unit"` is explicitly specified as `str`. 

Before (the `null`s are interpreted as `NaN`s.):
```
{
    "name": "LanguageCoverage - eight operations looped (pass: regular) - Instructions - Instructions",
    "unit": null,
    "value": 2097
  },
  {
    "name": "LanguageCoverage - eight operations looped (pass: regular) - Instructions - Malloc(total)",
    "unit": null,
    "value": 0
  },
```

This PR:
```
{
    "name": "LanguageCoverage - eight operations looped (pass: regular) - Instructions - Instructions",
    "unit": "",
    "value": 2097
  },
  {
    "name": "LanguageCoverage - eight operations looped (pass: regular) - Instructions - Malloc(total)",
    "unit": "",
    "value": 0
  },
```