### PR TITLE
feat: upload script for compile-time crashers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,11 @@
 
 name: tests
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+     - main
 
 jobs:
   compiletime-crash-tests:
@@ -19,7 +23,20 @@ jobs:
           python-version: "3.12"
       - name: Verify Python version
         run: python --version
+      - name: Install dependencies
+        run: |
+          python -m pip install "pandas~=2.2" "influxdb_client~=1.48"
+      - name: Verify package installation
+        run: python -c "import pandas as pd; print(pd.__version__); import influxdb_client; print(influxdb_client.__version__)"
       - run: (cd CompiletimeCrashTests && ./run-compiletime-crash-tests.sh)
+      - name: Upload to Influx
+        if: ${{ github.event_name == 'push' }}
+        env:
+          INFLUX_BUCKET_NAME: ${{ secrets.InfluxBucketName }}
+          INFLUX_UPLOAD_TOKEN: ${{ secrets.InfluxUploadToken }}
+          INFLUX_ORG_NAME: ${{ secrets.InfluxOrgName }}
+          INFLUX_URL: ${{ secrets.InfluxURL }}
+        run: cd RuntimePerformanceTests && python benchmark-upload.py
 
   runtime-crash-tests:
     name: Runtime Crash Tests Swift ${{ matrix.swift }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
           INFLUX_UPLOAD_TOKEN: ${{ secrets.InfluxUploadToken }}
           INFLUX_ORG_NAME: ${{ secrets.InfluxOrgName }}
           INFLUX_URL: ${{ secrets.InfluxURL }}
+          SWIFT_VERSION: ${{ matrix.swift }}
         run: cd RuntimePerformanceTests && python benchmark-upload.py
 
   runtime-crash-tests:

--- a/CompiletimeCrashTests/test-upload.py
+++ b/CompiletimeCrashTests/test-upload.py
@@ -19,8 +19,7 @@ def get_env(variable: str, description: str) -> str:
         raise EnvironmentError(f"Expected {description} to be in {variable}.")
     return result
 
-swift_version_info = run_cmd(['swift', '--version'])
-swift_version = swift_version_info.split("\n")[0]
+swift_version = get_env('SWIFT_VERSION')
 processor_type = run_cmd(['uname', '-m'])
 kernel_name = run_cmd(['uname', '-s'])
 kernel_version = run_cmd(['uname', '-r'])

--- a/CompiletimeCrashTests/test-upload.py
+++ b/CompiletimeCrashTests/test-upload.py
@@ -1,0 +1,56 @@
+import csv
+import json
+import subprocess
+
+from os import environ as env
+
+import influxdb_client
+
+def run_cmd(cmd: [str]) -> str:
+    result = subprocess.run(cmd)
+    err = result.returncode
+    if err:
+        raise EnvironmentError(f'Command {' '.join(cmd)} failed with error code {retcode}')
+    return str(result.stdout)
+
+def get_env(variable: str, description: str) -> str:
+    result = env.get(variable)
+    if not result:
+        raise EnvironmentError(f"Expected {description} to be in {variable}.")
+    return result
+
+swift_version_info = run_cmd(['swift', '--version'])
+processor_type = run_cmd(['uname', '-m'])
+kernel_name = run_cmd(['uname', '-s'])
+kernel_version = run_cmd(['uname', '-r'])
+
+results = None
+with open('compiletime-crash-test-results.json') as file:
+    results = json.loads(file.read())
+
+if not results:
+    raise ValueError('No results found!')
+
+url = get_env('INFLUX_URL', "Influx URL")
+token = get_env('INFLUX_UPLOAD_TOKEN', "Influx upload token")
+org = get_env('INFLUX_ORG_NAME', "org name")
+influx_client = influxdb_client.InfluxDBClient(
+    url=url,
+    token = token,
+    org=org
+)
+write_api = influx_client.write_api(write_options=influxdb_client.client.write_api.SYNCHRONOUS)
+
+github_ref = env.get('GITHUB_REF')
+commit_sha = env.get('GITHUB_SHA')
+bucket_name = env.get('INFLUX_BUCKET_NAME')
+
+for test, result in results.items():
+    point = influxdb_client.Point('compiletime-crash-tests')
+    point.tag('processorType', processor_type)
+    point.tag('kernelVersion', f"{kernel_name}-{kernel_version}")
+    point.tag('test', test)
+    point.field('status', result)
+    point.tag('ref', github_ref)
+    point.tag('commit', commit_sha)
+    write_api.write(bucket=bucket_name, record=point)

--- a/CompiletimeCrashTests/test-upload.py
+++ b/CompiletimeCrashTests/test-upload.py
@@ -7,11 +7,11 @@ from os import environ as env
 import influxdb_client
 
 def run_cmd(cmd: [str]) -> str:
-    result = subprocess.run(cmd)
+    result = subprocess.run(cmd, capture_output=True)
     err = result.returncode
     if err:
         raise EnvironmentError(f'Command {' '.join(cmd)} failed with error code {retcode}')
-    return str(result.stdout)
+    return result.stdout.decode()
 
 def get_env(variable: str, description: str) -> str:
     result = env.get(variable)
@@ -20,6 +20,7 @@ def get_env(variable: str, description: str) -> str:
     return result
 
 swift_version_info = run_cmd(['swift', '--version'])
+swift_version = swift_version_info.split("\n")[0]
 processor_type = run_cmd(['uname', '-m'])
 kernel_name = run_cmd(['uname', '-s'])
 kernel_version = run_cmd(['uname', '-r'])
@@ -53,4 +54,7 @@ for test, result in results.items():
     point.field('status', result)
     point.tag('ref', github_ref)
     point.tag('commit', commit_sha)
+    point.tag('swiftVersion', swift_version)
+    print(point)
+    continue
     write_api.write(bucket=bucket_name, record=point)

--- a/CompiletimeCrashTests/test-upload.py
+++ b/CompiletimeCrashTests/test-upload.py
@@ -50,6 +50,7 @@ for test, result in results.items():
     point = influxdb_client.Point('compiletime-crash-tests')
     point.tag('processorType', processor_type)
     point.tag('kernelVersion', f"{kernel_name}-{kernel_version}")
+    point.tag('testclass', "crasher")
     point.tag('test', test)
     point.field('status', result)
     point.tag('ref', github_ref)


### PR DESCRIPTION
This PR adds a script and CI step to upload compile-time crash results to an internal Influx DB bucket. Currently, there are two important changes to the test CI workflow.
1. The tests are also going to run when a PR is rebased and merged with `main`.
2. The upload script will only be run when the trigger is `push`, and not on `pull_request`.
