### PR TITLE
fix: run the correct command for crash tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           INFLUX_ORG_NAME: ${{ secrets.InfluxOrgName }}
           INFLUX_URL: ${{ secrets.InfluxURL }}
           SWIFT_VERSION: ${{ matrix.swift }}
-        run: cd RuntimePerformanceTests && python benchmark-upload.py
+        run: cd CompiletimeCrashTests && python test-upload.py
 
   runtime-crash-tests:
     name: Runtime Crash Tests Swift ${{ matrix.swift }}


### PR DESCRIPTION
Fix for [this](https://github.com/differentiable-swift/swift-differentiation-testing/actions/runs/14447167355/job/40510474806).