### PR TITLE
ci: use self-hosted runners for benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,5 +1,6 @@
 name: Differentiation Benchmarks
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -11,7 +12,9 @@ permissions:
 jobs:
   benchmark:
     name: Run Differentiation benchmarks
-    runs-on: ubuntu-latest
+    runs-on:
+      group: Benchmark Runners
+      labels: [self-hosted, Linux, ARM64, benchmark-runner]
     strategy:
       matrix:
         swift: ["6.0.3"]


### PR DESCRIPTION
Replaces the GitHub runners for our repository's benchmark runners. In addition to `push` on `main`, a `workflow_dispatch` trigger has been added for manually triggering workflow runs.

# Security
Do we as maintainers wish to maintain the following?
- The benchmark job can only be run by the maintainers, either manually or by merging a PR.
- The settings for benchmark runners can be found [here](https://github.com/organizations/differentiable-swift/settings/actions/runner-groups/3). This is the only public repository for which self-hosted runners can be used.
- External contributions will have to be reviewed thoroughly for malicious code that e.g. that tries to dump secrets. 

