### PR TITLE
Feat/nightly main compiletime crashers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ on:
 jobs:
   compiletime-crash-tests:
     name: Compiletime Crash Tests Swift ${{ matrix.swift }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         swift: ["6.0.3", "6.1.0", "nightly-main"]
-    container: swift:${{ matrix.swift }}
+    container: ${{ contains(matrix.swift, 'nightly') && format('swiftlang/swift:{0}', matrix.swift) || format('swift:{0}', matrix.swift) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -59,7 +59,7 @@ jobs:
         run: python --version
       - name: Install dependencies
         run: |
-          python -m pip install "pandas~=2.2" "influxdb_client~=1.48"
+          python -m pip install "pandas~=2.2" "influxdb_client~=1.48" "result~=0.17" "typeguard~=4.4"
       - name: Verify package installation
         run: python -c "import pandas as pd; print(pd.__version__); import influxdb_client; print(influxdb_client.__version__)"
       - name: Install swiftly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        swift: ["6.0.3", "6.1.0"]
+        swift: ["6.0.3", "6.1.0", "main-snapshot", "6.2-snapshot"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ name: tests
 on:
   workflow_dispatch:
   pull_request:
+  schedule:
+    - cron: '0 0 * * *' # Every day at midnight UTC
   push:
     branches:
      - main
@@ -34,7 +36,7 @@ jobs:
           SWIFT_VERSION: ${{ matrix.swift }}
         run: (cd CompiletimeCrashTests && ./run-compiletime-crash-tests.sh)
       - name: Upload to Influx
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' || github.event.name == 'schedule' }}
         env:
           INFLUX_BUCKET_NAME: ${{ secrets.InfluxBucketName }}
           INFLUX_UPLOAD_TOKEN: ${{ secrets.InfluxUploadToken }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        swift: ["6.0.3", "6.1.0", "nightly-main"]
+        swift: ["6.0.3", "6.1.0", "nightly-main", "nightly-6.2-jammy"]
     container: ${{ contains(matrix.swift, 'nightly') && format('swiftlang/swift:{0}', matrix.swift) || format('swift:{0}', matrix.swift) }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         run: python --version
       - name: Install dependencies
         run: |
-          python -m pip install "pandas~=2.2" "influxdb_client~=1.48"
+          python -m pip install "pandas~=2.2" "influxdb_client~=1.48" "result~=0.17" "typeguard~=4.4"
       - name: Verify package installation
         run: python -c "import pandas as pd; print(pd.__version__); import influxdb_client; print(influxdb_client.__version__)"
       - name: Run compiletime crash tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        swift: ["6.0.3", "6.1.0"]
+        swift: ["6.0.3", "6.1.0", "nightly-main"]
     container: swift:${{ matrix.swift }}
     steps:
       - uses: actions/checkout@v4

--- a/CompiletimeCrashTests/AlwaysFail/build.sh
+++ b/CompiletimeCrashTests/AlwaysFail/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/AlwaysPass/build.sh
+++ b/CompiletimeCrashTests/AlwaysPass/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c001-unsupported-collection-upcast-kind/build.sh
+++ b/CompiletimeCrashTests/c001-unsupported-collection-upcast-kind/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c002-assertion-failure-throwing-function-within-gradient/build.sh
+++ b/CompiletimeCrashTests/c002-assertion-failure-throwing-function-within-gradient/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c003-nil-coalescing-silgen-crash/build.sh
+++ b/CompiletimeCrashTests/c003-nil-coalescing-silgen-crash/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c004-differentiable-func-returns-result-of-another-differentiable-func-A/build.sh
+++ b/CompiletimeCrashTests/c004-differentiable-func-returns-result-of-another-differentiable-func-A/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c005-differentiability-analysis-too-strict-non-differentiable-arg/build.sh
+++ b/CompiletimeCrashTests/c005-differentiability-analysis-too-strict-non-differentiable-arg/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c006-synthesized-tangent-vectors-no-longer-extensible/build.sh
+++ b/CompiletimeCrashTests/c006-synthesized-tangent-vectors-no-longer-extensible/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c007-conformance-of-synthesized-tangent-vector/build.sh
+++ b/CompiletimeCrashTests/c007-conformance-of-synthesized-tangent-vector/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c008-curry-thunk-differentiation-original/build.sh
+++ b/CompiletimeCrashTests/c008-curry-thunk-differentiation-original/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c009-control-flow-dominated-active-value-no-tangent-space/build.sh
+++ b/CompiletimeCrashTests/c009-control-flow-dominated-active-value-no-tangent-space/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c011-assertion-failed-adjoint-buffer-exists/build.sh
+++ b/CompiletimeCrashTests/c011-assertion-failed-adjoint-buffer-exists/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c012-sil-verification-failed-method-not-in-vtable/build.sh
+++ b/CompiletimeCrashTests/c012-sil-verification-failed-method-not-in-vtable/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c013-need-generic-signature/build.sh
+++ b/CompiletimeCrashTests/c013-need-generic-signature/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swift build -v 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c014-assertion-srcAddr-getType-destAddr-getType/build.sh
+++ b/CompiletimeCrashTests/c014-assertion-srcAddr-getType-destAddr-getType/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c014-differentiable-func-returns-result-of-another-differentiable-func-B/build.sh
+++ b/CompiletimeCrashTests/c014-differentiable-func-returns-result-of-another-differentiable-func-B/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c016-custom-vjp-triggers-assertion-internal-unserializable/build.sh
+++ b/CompiletimeCrashTests/c016-custom-vjp-triggers-assertion-internal-unserializable/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c017-differentiation-transform-library-evoluation-leaked-owned-values-never-consumed/build.sh
+++ b/CompiletimeCrashTests/c017-differentiation-transform-library-evoluation-leaked-owned-values-never-consumed/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c018-curry-thunk-differentiation-narrowed/build.sh
+++ b/CompiletimeCrashTests/c018-curry-thunk-differentiation-narrowed/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c019-exact-type-for-generic-param-in-differentiable-minimized/build.sh
+++ b/CompiletimeCrashTests/c019-exact-type-for-generic-param-in-differentiable-minimized/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c020-vtable-entry-type-mismatch/build.sh
+++ b/CompiletimeCrashTests/c020-vtable-entry-type-mismatch/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c021-generated-declaration-mangling/build.sh
+++ b/CompiletimeCrashTests/c021-generated-declaration-mangling/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c022-conflicting-debug-info-inlining/build.sh
+++ b/CompiletimeCrashTests/c022-conflicting-debug-info-inlining/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c023-GenericTypeParamDecl-ast-verification-test/build.sh
+++ b/CompiletimeCrashTests/c023-GenericTypeParamDecl-ast-verification-test/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c024-conflicting-debug-info-inlining/build.sh
+++ b/CompiletimeCrashTests/c024-conflicting-debug-info-inlining/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c025-no-derivative-parameter-type-mangling/build.sh
+++ b/CompiletimeCrashTests/c025-no-derivative-parameter-type-mangling/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c026-linux-ld-tangent-value-category-mismatch/build.sh
+++ b/CompiletimeCrashTests/c026-linux-ld-tangent-value-category-mismatch/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c027-nested-differentiation-of-extension-method-optimized/build.sh
+++ b/CompiletimeCrashTests/c027-nested-differentiation-of-extension-method-optimized/build.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 # NB: must be optimized build
 swiftc -O main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c028-ld-vjpcloner-apply-multiple-consuming-users/build.sh
+++ b/CompiletimeCrashTests/c028-ld-vjpcloner-apply-multiple-consuming-users/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c029-flaky-over-consume-in-subset-parameters-thunk/build.sh
+++ b/CompiletimeCrashTests/c029-flaky-over-consume-in-subset-parameters-thunk/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/c030-assertion-srcAddr-getType-destAddr-getType/build.sh
+++ b/CompiletimeCrashTests/c030-assertion-srcAddr-getType-destAddr-getType/build.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 swiftc main.swift -o main 2>&1 | ../check.py
-RETURN_CODE=$?

--- a/CompiletimeCrashTests/check.py
+++ b/CompiletimeCrashTests/check.py
@@ -21,7 +21,7 @@ class ReproducerType(Enum):
     ERROR = 3   # should build successfully, but throws compilation error
 
     @staticmethod
-    def parse(header: str) -> type[Self | None]:
+    def parse(header: str) -> Optional[Self]:
         match = re.match(HEADER_REGEX, header)
         if match:
             return ReproducerType[match.group(1)]

--- a/CompiletimeCrashTests/check.py
+++ b/CompiletimeCrashTests/check.py
@@ -169,7 +169,7 @@ def main():
     expected_output = expected_output[1:]
     match result := check(expected_output, compiler_output):
         case None:
-            print(reproducer_type)
+            print(str(reproducer_type).split('.')[-1])
             exit(0)
         case TestFailure(found_line, expected) as err:
             if "nightly" not in swift_version:
@@ -180,7 +180,7 @@ def main():
         case _ as result:
             assert False, f"Unreachable: {result}"
 
-    print(check_weak_nightly(compiler_output))
+    print(str(check_weak_nightly(compiler_output)).split('.')[-1])
 
 
 if __name__ == '__main__':

--- a/CompiletimeCrashTests/check.py
+++ b/CompiletimeCrashTests/check.py
@@ -38,7 +38,7 @@ class MissingHeader(CheckError):
 class TestFailure(CheckError):
     __match_args__ = ("found_line", "expected")
     def __init__(self, found_line: str, expected: [str]):
-        message = f"FAIL: \"{found_line} not found in \"{"".join(expected)}\"\""
+        message = f"FAIL: `{found_line}` not found in `{"".join(expected)}`"
         super().__init__(message)
         self.found_line = found_line
         self.expected = expected

--- a/CompiletimeCrashTests/check.py
+++ b/CompiletimeCrashTests/check.py
@@ -178,7 +178,7 @@ def main():
             print(str(reproducer_type).split('.')[-1])
             exit(0)
         case TestFailure(found_line, expected) as err:
-            if "nightly" not in swift_version:
+            if "nightly" not in swift_version and "snapshot" not in swift_version:
                 raise err
             # nightly to be handled next
         case Err(err):

--- a/CompiletimeCrashTests/check.py
+++ b/CompiletimeCrashTests/check.py
@@ -36,11 +36,12 @@ class MissingHeader(CheckError):
         super().__init__(f"Expected a reproducer type header of the form {HEADER_REGEX}.")
 
 class TestFailure(CheckError):
-    def __init__(self, found: str, expected: [str]):
-        message = f"FAIL: \"{expected_line} not found in \"{"".join(found)}\"\""
+    __match_args__ = ("found_line", "expected")
+    def __init__(self, found_line: str, expected: [str]):
+        message = f"FAIL: \"{found_line} not found in \"{"".join(expected)}\"\""
         super().__init__(message)
-        self.missing_line = expected
-        self.found = found
+        self.found_line = found_line
+        self.expected = expected
 
 
 def errprint(*args, **kwargs):

--- a/CompiletimeCrashTests/check.py
+++ b/CompiletimeCrashTests/check.py
@@ -36,12 +36,16 @@ class MissingHeader(CheckError):
         super().__init__(f"Expected a reproducer type header of the form {HEADER_REGEX}.")
 
 class TestFailure(CheckError):
-    __match_args__ = ("found_line", "expected")
-    def __init__(self, found_line: str, expected: [str]):
-        message = f"FAIL: `{found_line}` not found in `{"".join(expected)}`"
+    __match_args__ = ("expected_line", "found")
+    def __init__(self, expected_line: str, found: [str]):
+        message = (
+            f"FAIL: `{expected_line}` not found in compiler output `{"\n".join(found)}`"
+            if expected_line
+            else f"FAIL: expected no compiler output, found {"\n".join(found)}"
+        )
         super().__init__(message)
-        self.found_line = found_line
-        self.expected = expected
+        self.expected_line = expected_line
+        self.found = found
 
 
 def errprint(*args, **kwargs):
@@ -125,6 +129,8 @@ def maybe_error(compiler_output: list[str]) -> bool:
 def check(expected: list[str], found: list[str]) -> Optional[TestFailure]:
     if not expected and not found:
         return
+    elif not expected:
+        return TestFailure("", found)
     idx = 0
     expected_line = expected[idx]
     for line in found:

--- a/CompiletimeCrashTests/run-compiletime-crash-tests.sh
+++ b/CompiletimeCrashTests/run-compiletime-crash-tests.sh
@@ -7,31 +7,6 @@ if [[ $OSTYPE == 'darwin'* ]]; then
         export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
 fi
 
-# `get_reproduce_type(file)`
-# Reads the first line of `file` and tries to parse it as a reproducer type header.
-# A header is expected to be of the PCRE form ^#\s*(OK|ERROR|CRASH|XERROR)
-# - OK: compiles successfully
-# - ERROR: expected to compile successfully, but throws a compilation error with some diagnostic --OR-- expected to throw a compilation error, but compiler presents a different diagnostic
-# - XERROR: expected to throw compilation error with correct diagnostic
-# - CRASH: crashes the compiler
-get_reproducer_type() {
-    local file="$1"
-    local first_line
-    if [[ ! -e $file ]]; then
-        echo "OK"
-        return 0
-    fi
-    first_line=$(head -n 1 "$file" 2>/dev/null)
-    if [[ $first_line =~ ^#[[:space:]]*(OK|ERROR|CRASH|XERROR) ]]; then
-        # capture groups not working?
-        # echo ="${BASH_REMATCH[1]}"
-        # strips "#\s*" from the left, and spaces and newlines from the right
-        echo `echo $first_line | sed 's/^[[:space:]]*# *//;s/[[:space:]]*$//'`
-    else
-        echo "ERROR: No header match"
-        exit 1
-    fi
-}
 
 declare -A test_results
 
@@ -39,15 +14,15 @@ for folder in $(find . -type d -mindepth 1 -maxdepth 1 | sed 's|^\./||'); do
     let total_count+=1
     cd "$folder" # navigate to current testing folder
     echo "Building and checking output of $folder"
-    source ./build.sh # is expected to set RETURN_CODE variable
+    reproducer_type=`source ./build.sh`
+    RETURN_CODE=$?
     echo "Finished building $folder"
-    reproducer_type=$(get_reproducer_type "expected-${SWIFT_VERSION}-`uname -s`.txt")
     cd - > /dev/null # navigate back to previous folder
     test_results[$folder]=$reproducer_type
     # script expected to succeed
     if [ $RETURN_CODE -eq 0 ]; then
         # script succeeded
-        echo -e "$folder: $reproducer_type (expected)\n"
+        echo -e "$folder: $reproducer_type\n"
         if [[ "$reproducer_type" = "ERROR" || "$reproducer_type" = "CRASH" ]]; then
             fail_count=$((fail_count + 1))
         fi


### PR DESCRIPTION
This PR adds ad-hoc compile-time crash tests for nightly swift versions. 

# Motivation
We would like to be able to monitor the status of these crashers for nightly Swift versions and plot e.g. a [state timeline](https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/state-timeline/) and number/ratio of passing tests over time.

# Implementation
1. The reference output for any nightly version defaults to the latest available stable release version (in this case 6.1.0)
2. If the output for a nightly-compilation differs from the reference output, a dead-simple grep is used to determine the compilation result
  - If the compiler output is empty, it's `OK`
  - Else if `Stack dump` is found in the compiler output, it is a crasher (`CRASH`)
  - Else if `error:` is found in the compiler output, it is an unexpected compilation error (note that expected compilation error is expected to match in the first step when comparing against reference output) (`ERROR`)
  - Else it's assumed to be `OK` (output is most likel ya warning)

# TODO
- Is it a good idea to assume `OK` if neither `ERROR` nor `CRASH` are detected for nightlies?
- The compiler outputs of all nightly runs should probably be stored as an artifact
- macOS needs to be handled separately -- `swiftly` only lists `main-snapshot`, which shows up as 6.2-DEV  in `swift --version`.
Should these be handled in this PR, or a separate one?