### PR TITLE
CI/fix macos compiletime test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
           SWIFT_VERSION: ${{ matrix.swift }}
         run: cd CompiletimeCrashTests && ./run-compiletime-crash-tests.sh
       - name: Upload to Influx
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' || github.event.name == 'schedule' }}
         env:
           INFLUX_BUCKET_NAME: ${{ secrets.InfluxBucketName }}
           INFLUX_UPLOAD_TOKEN: ${{ secrets.InfluxUploadToken }}

--- a/CompiletimeCrashTests/run-compiletime-crash-tests.sh
+++ b/CompiletimeCrashTests/run-compiletime-crash-tests.sh
@@ -48,6 +48,7 @@ for i in "${!test_keys[@]}"; do
 done
 json+="}"
 
+echo $json
 echo $json > compiletime-crash-test-results.json
 
 echo "Finished running all Compiletime Crash tests"

--- a/CompiletimeCrashTests/run-compiletime-crash-tests.sh
+++ b/CompiletimeCrashTests/run-compiletime-crash-tests.sh
@@ -14,12 +14,12 @@ test_values=()
 
 for folder in $(find . -type d -mindepth 1 -maxdepth 1 | sed 's|^\./||'); do
     let total_count+=1
-    cd "$folder" # navigate to current testing folder
+    cd "$folder" || exit 1 # navigate to current testing folder, avoid silent failures
     echo "Building and checking output of $folder"
     reproducer_type=`source ./build.sh`
     RETURN_CODE=$?
     echo "Finished building $folder"
-    cd - > /dev/null # navigate back to previous folder
+    cd - > /dev/null  || exit 1 # navigate back to previous folder, avoid silent failure
     # script expected to succeed
     test_keys+=("$folder")
     test_values+=("$reproducer_type")

--- a/CompiletimeCrashTests/run-compiletime-crash-tests.sh
+++ b/CompiletimeCrashTests/run-compiletime-crash-tests.sh
@@ -7,8 +7,10 @@ if [[ $OSTYPE == 'darwin'* ]]; then
         export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
 fi
 
+# Use indexed arrays instead of associative arrays
+test_keys=()
+test_values=()
 
-declare -A test_results
 
 for folder in $(find . -type d -mindepth 1 -maxdepth 1 | sed 's|^\./||'); do
     let total_count+=1
@@ -18,8 +20,9 @@ for folder in $(find . -type d -mindepth 1 -maxdepth 1 | sed 's|^\./||'); do
     RETURN_CODE=$?
     echo "Finished building $folder"
     cd - > /dev/null # navigate back to previous folder
-    test_results[$folder]=$reproducer_type
     # script expected to succeed
+    test_keys+=("$folder")
+    test_values+=("$reproducer_type")
     if [ $RETURN_CODE -eq 0 ]; then
         # script succeeded
         echo -e "$folder: $reproducer_type\n"
@@ -35,14 +38,13 @@ done
 
 # format JSON
 json="{"
-first=1
-for test in "${!test_results[@]}"; do
-    value=${test_results[$test]}
-    if [[ $first -eq 0 ]]; then
+for i in "${!test_keys[@]}"; do
+    key=${test_keys[$i]}
+    value=${test_values[$i]}
+    if [ $i -ne 0 ]; then
         json+=", "
     fi
-    json+="\"$test\": \"$value\" "
-    first=0
+    json+="\"$key\": \"$value\""
 done
 json+="}"
 

--- a/CompiletimeCrashTests/run-compiletime-crash-tests.sh
+++ b/CompiletimeCrashTests/run-compiletime-crash-tests.sh
@@ -48,7 +48,7 @@ for i in "${!test_keys[@]}"; do
 done
 json+="}"
 
-echo $json
+echo "TRACE: ${json}"
 echo $json > compiletime-crash-test-results.json
 
 echo "Finished running all Compiletime Crash tests"


### PR DESCRIPTION
Couple of fixes.
- Turns out the CI runners use `bash 3.2` or something, which means that associative arrays (the dict-like things) do not work. Annoying that it did not show up as an error and the CI showed the script is passing: https://github.com/differentiable-swift/swift-differentiation-testing/actions/runs/15049138829/job/42299256727#step:10:16
- Forgot to let the macOS job run on schedule