### PR TITLE
ci: allow test data upload for manual CI runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           SWIFT_VERSION: ${{ matrix.swift }}
         run: (cd CompiletimeCrashTests && ./run-compiletime-crash-tests.sh)
       - name: Upload to Influx
-        if: ${{ github.event_name == 'push' || github.event.name == 'schedule' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         env:
           INFLUX_BUCKET_NAME: ${{ secrets.InfluxBucketName }}
           INFLUX_UPLOAD_TOKEN: ${{ secrets.InfluxUploadToken }}
@@ -81,7 +81,7 @@ jobs:
           SWIFT_VERSION: ${{ matrix.swift }}
         run: cd CompiletimeCrashTests && ./run-compiletime-crash-tests.sh
       - name: Upload to Influx
-        if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         env:
           INFLUX_BUCKET_NAME: ${{ secrets.InfluxBucketName }}
           INFLUX_UPLOAD_TOKEN: ${{ secrets.InfluxUploadToken }}


### PR DESCRIPTION
Allow uploading test results during manually run workflow jobs.
Also typo fix.